### PR TITLE
Gaussian synchrotron simulations in total intensity

### DIFF
--- a/so_pysm_models/__init__.py
+++ b/so_pysm_models/__init__.py
@@ -28,3 +28,5 @@ if sys.version_info < tuple(
 if not _ASTROPY_SETUP_:
     # For egg_info test builds to pass, put package imports here.
     pass
+
+from .synchrotron import GaussianSynchrotron

--- a/so_pysm_models/laws.py
+++ b/so_pysm_models/laws.py
@@ -1,0 +1,52 @@
+import numpy as np
+
+
+def power_law(nu, nu_ref_s, beta_s):
+    """ Function to compute power law SED.
+    Parameters
+    ----------
+    nu: float, or array_like(float)
+        Frequency in GHz.
+    beta_s: float
+        Power law index in RJ units.
+    Returns
+    -------
+    array_like(float)
+        SED relative to reference frequency.
+    """
+    x = nu / nu_ref_s
+    sed = x ** beta_s
+    return sed
+
+
+def curved_power_law(nu, nu_ref_s, beta_s, beta_c):
+    """ Function to compute curved power law SED.
+    Parameters
+    ----------
+    nu: float, or array_like(float)
+        Frequency in GHz.
+    beta_s: float
+        Power law index in RJ units.
+    beta_c: float
+        Power law index curvature.
+    Returns
+    -------
+    array_like(float)
+        SED relative to reference frequency.
+    """
+    x = nu / nu_ref_s
+    sed = x ** (beta_s + beta_c * np.log(nu / nu_ref_s))
+    return sed
+
+
+def black_body_cmb(nu):
+    """ Function to compute CMB SED.
+    Parameters
+    ----------
+    nu: float, or array_like(float)
+        Frequency in GHz.
+    """
+    x = 0.0176086761 * nu
+    ex = np.exp(x)
+    sed = ex * (x / (ex - 1)) ** 2
+    return sed

--- a/so_pysm_models/synchrotron.py
+++ b/so_pysm_models/synchrotron.py
@@ -1,0 +1,122 @@
+import numpy as np
+
+import healpy as hp
+
+from . import laws
+
+
+class GaussianSynchrotron:
+
+    def __init__(
+        self,
+        target_nside,
+        has_polarization=True,
+        pixel_indices=None,
+        EE_amplitude=4.3,
+        EtoB=0.5,
+        alpha=-1.0,
+        beta=-3.1,
+        curv=0.,
+        nu_0=23.,
+        verbose=False,
+    ):
+        """Gaussian synchrotron model
+
+        Parameters
+        ----------
+        target_nside : int
+            HEALPix NSIDE of the output maps
+        pixel_indices : ndarray of ints
+            Outputa partial maps given HEALPix pixel indices in RING ordering
+        EE_amplitude : float
+            amplitude of the synchrotron EE power spectrum (D_ell) at the reference
+            frequency and ell=80, in muK^2 and thermodinamic units.
+            Default: 4.3 from the amplitude of S-PASS E-modes power spectrum at 2.3GHz
+            in the region covered by SO-SAT, rescaled at 23GHz with a powerlaw with
+            beta_s = -3.1
+        EtoB : float
+            ratio between E and B-mode amplitude.
+            Default: 0.5 from Krachmalnicoff et al. 2018
+        alpha : spectral tilt of the synchrotron power spectrum (D_ell).
+            Default: -1.0 from Krachmalnicoff et al. 2018
+        beta : synchrotron spectral index.
+            Default: -3.1 from Planck 2018 IX
+        curv : synchrotron curvature index.
+            Default: 0.
+        nu_0 : synchrotron reference frequency in GHz.
+            Default: 23
+        """
+
+        self.target_nside = target_nside
+        self.pixel_indices = pixel_indices
+        self.has_polarization = has_polarization
+        self.EE_amplitude = EE_amplitude
+        self.EtoB = EtoB
+        self.alpha = alpha
+        self.beta = beta
+        self.curv = curv
+        self.nu_0 = nu_0
+        self.verbose = verbose
+
+    def signal(self, nu, **kwargs):
+        """Return map in uK_RJ at given frequency or array of frequencies"""
+
+        nell = 3 * self.target_nside
+        try:
+            nnu = len(nu)
+        except TypeError:
+            nnu = 1
+            nu = np.array([nu])
+        ell = np.arange(nell)
+        dl_prefac = 2 * np.pi / ((ell + 0.01) * (ell + 1))
+        clZERO = np.zeros_like(ell)
+        clTT_sync = clZERO
+        clTE_sync = clZERO
+        clEE_sync = (
+            dl_prefac
+            * self.EE_amplitude
+            * ((ell + 0.1) / 80.) ** self.alpha
+            * laws.black_body_cmb(self.nu_0) ** 2
+        )
+        BB_amplitude = self.EE_amplitude * self.EtoB
+        clBB_sync = (
+            dl_prefac
+            * BB_amplitude
+            * ((ell + 0.1) / 80.) ** self.alpha
+            * laws.black_body_cmb(self.nu_0) ** 2
+        )
+        spec_sync = laws.curved_power_law(nu, self.nu_0, self.beta, self.curv)
+        clt_sync = np.zeros([3, nnu, nnu, nell])
+        clt_sync[0] = (
+            clTT_sync[None, None, :]
+            * spec_sync[:, None, None]
+            * spec_sync[None, :, None]
+        )
+        clt_sync[1] = (
+            clEE_sync[None, None, :]
+            * spec_sync[:, None, None]
+            * spec_sync[None, :, None]
+        )
+        clt_sync[2] = (
+            clBB_sync[None, None, :]
+            * spec_sync[:, None, None]
+            * spec_sync[None, :, None]
+        )
+        # Generate foreground maps
+        amp_sync = np.array(
+            hp.synfast(
+                [clTT_sync, clEE_sync, clBB_sync, clTE_sync, clZERO, clZERO],
+                self.target_nside,
+                pol=True,
+                new=True,
+                verbose=False,
+            )
+        )
+        out = amp_sync[None, :, :] * spec_sync[:, None, None]
+
+        # the output of out is always 3D, (num_freqs, IQU, npix), if num_freqs is one
+        # we return only a 2D array.
+        if len(out) == 1:
+            return out[0]
+        else:
+            return out


### PR DESCRIPTION
Implementation of gaussian synchrotron simulation also for total intensity map.

The difference between stokes Q/U and I is that we want the total intensity map to be positive everywhere, meaning that the same implementation used for Q/U cannot be applied in this case.

The way I bypass this problem is the following:
1. I generate a power-law TT power spectrum: Cl \propto ell^alpha
2. I put Cl[0]=0
3. I generate a temperature map T as a gaussian realization of this power spectrum
4. I add at this T map an offset whose value is taken from a reference map (in this case the offset is the mean value of the pysm T map at 23 GHz in the SO-SAT region)
5. I check whether the T+offset map is positive everywhere
6. If not I applied a cut in the TT power spectrum in the following way: Cl[1:lcut] = cl[lcut] and generate again the T+offset map. The value of lcut is the minimum one for which T+offset is positive everywhere

Typical values for lcut are between ell=4 and ell=9, depending on realization (and also on the Nside of the output map). 
This implementation removes some power at the very large scales, which nevertheless are nor probed by SO. 

The code is slower now, as it has to generate the output map several times, until T is positive everywhere. 
