### PR TITLE
Minor type fix

### DIFF
--- a/so_pysm_models/alms.py
+++ b/so_pysm_models/alms.py
@@ -9,7 +9,6 @@ import pysm
 
 
 class PrecomputedAlms(object):
-
     def __init__(
         self,
         filename,
@@ -69,7 +68,7 @@ class PrecomputedAlms(object):
         at 148 GHz. The value 148 Ghz does not matter if the output is in
         uK.
         """
-
+        
         try:
             nnu = len(nu)
         except TypeError:
@@ -78,11 +77,10 @@ class PrecomputedAlms(object):
 
         # use tile to output the same map for all frequencies
         out = np.tile(self.output_map, (nnu, 1, 1))
-        if self.wcs is not None:
-            out = enmap.enmap(out, self.wcs)
-        out *= pysm.convert_units(self.input_units, output_units, nu).reshape(
+        if self.wcs is not None: out = enmap.enmap(out, self.wcs)
+        out = out * pysm.convert_units(self.input_units, output_units, nu).reshape(
             (nnu, 1, 1)
-        )
+        ).astype(float)
 
         # the output of out is always 3D, (num_freqs, IQU, npix), if num_freqs is one
         # we return only a 2D array.


### PR DESCRIPTION
I get type casting errors. These minor changes fix it.

Here is the full output for the error:
```
$ python setup.py test
The requested path 'astropy_helpers' for importing astropy_helpers does not exist, or does not contain a copy of the astropy_helpers package.
Downloading 'astropy-helpers'; run setup.py with the --offline option to force offline installation.
running test
installing to temporary directory: /tmp/mapsims-test-0opn78p3
warning: no files found matching 'README.rst'
warning: no files found matching 'CHANGES.rst'
warning: no files found matching '*.pyx' under directory 'mapsims'
warning: no files found matching '*.c' under directory 'mapsims'
warning: no files found matching '*.pxd' under directory 'mapsims'
warning: no files found matching '*' under directory 'cextern'
warning: no files found matching '*' under directory 'scripts'
no previously-included directories found matching 'build'
no previously-included directories found matching 'docs/_build'
no previously-included directories found matching 'docs/api'
warning: no files found matching 'astropy_helpers/README.rst'
warning: no files found matching 'astropy_helpers/CHANGES.rst'
warning: no files found matching 'astropy_helpers/LICENSE.rst'
warning: no files found matching '*' under directory 'astropy_helpers/licenses'
warning: no files found matching 'astropy_helpers/ah_bootstrap.py'
warning: no files found matching '*.py' under directory 'astropy_helpers/astropy_helpers'
warning: no files found matching '*.pyx' under directory 'astropy_helpers/astropy_helpers'
warning: no files found matching '*.c' under directory 'astropy_helpers/astropy_helpers'
warning: no files found matching '*.h' under directory 'astropy_helpers/astropy_helpers'
warning: no files found matching '*.rst' under directory 'astropy_helpers/astropy_helpers'
warning: no files found matching '*' under directory 'astropy_helpers/astropy_helpers.egg-info'
warning: no files found matching '*' under directory 'astropy_helpers/astropy_helpers/sphinx'
no previously-included directories found matching 'astropy_helpers/build'
no previously-included directories found matching 'astropy_helpers/astropy_helpers/tests'
warning: no previously-included files matching '*.pyc' found anywhere in distribution
warning: no previously-included files matching '*.o' found anywhere in distribution
================================================================ test session starts ================================================================
platform linux -- Python 3.7.1, pytest-4.0.2, py-1.7.0, pluggy-0.8.0

Running tests with Astropy version 3.1.
Running tests in mapsims docs.

Date: 2019-01-03T00:57:55

Platform: Linux-4.19.12-arch1-1-ARCH-x86_64-with-arch

Executable: /usr/bin/python

Full Python Version: 
3.7.1 (default, Oct 22 2018, 10:41:28) 
[GCC 8.2.1 20180831]

encodings: sys: utf-8, locale: UTF-8, filesystem: utf-8
byteorder: little
float info: dig: 15, mant_dig: 15

Numpy: 1.15.4
Scipy: 1.2.0
Matplotlib: 3.0.2
h5py: 2.9.0
Pandas: 0.23.4
astropy_helpers: 3.1
Using Astropy options: remote_data: none.

rootdir: /tmp/mapsims-test-0opn78p3/lib/python3.7/site-packages, inifile: setup.cfg
plugins: remotedata-0.3.1, openfiles-0.3.1, doctestplus-0.2.0, cov-2.6.0, arraydiff-0.3
collected 4 items                                                                                                                                   

mapsims/data/README.rst .                                                                                                                     [ 25%]
mapsims/tests/test_cmb.py F                                                                                                                   [ 50%]
docs/index.rst .                                                                                                                              [ 75%]
docs/mapsims/index.rst .                                                                                                                      [100%]

===================================================================== FAILURES ======================================================================
___________________________________________________________________ test_load_sim ___________________________________________________________________

    def test_load_sim():
        save_name = get_pkg_data_filename("../data/test_map.fits")
        cmb_dir = os.path.dirname(save_name)
        nside = 32
        # Make an IQU sim
        imap = cmb.get_cmb_sky(
>           iteration_num=0, nside=nside, cmb_dir=cmb_dir, lensed=False, aberrated=False
        )

mapsims/tests/test_cmb.py:17: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
mapsims/cmb/__init__.py:75: in get_cmb_sky
    return sgen.signal(nu=nu, modulation=modulation)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <so_pysm_models.alms.PrecomputedAlms object at 0x7ff7b0c57128>, nu = array([None], dtype=object), output_units = 'uK_RJ'
kwargs = {'modulation': False}, nnu = 1
out = array([[[ 2.94333165e+01, -4.20552399e+00,  1.49759973e+00, ...,
         -2.03730466e+01, -5.31107402e+01, -3.0050457...[ 1.07700638e+05, -1.39822654e+05,  2.27070254e+05, ...,
         -2.17407559e+05,  3.02683135e+05, -3.63234124e+05]]])

    def signal(self, nu=[148.], output_units="uK_RJ", **kwargs):
        """Return map in uK_RJ at given frequency or array of frequencies
    
        If nothing is specified for nu, we default to providing an unmodulated map
        at 148 GHz. The value 148 Ghz does not matter if the output is in
        uK.
        """
    
        try:
            nnu = len(nu)
        except TypeError:
            nnu = 1
            nu = np.array([nu])
    
        # use tile to output the same map for all frequencies
        out = np.tile(self.output_map, (nnu, 1, 1))
        if self.wcs is not None:
            out = enmap.enmap(out, self.wcs)
        out *= pysm.convert_units(self.input_units, output_units, nu).reshape(
>           (nnu, 1, 1)
        )
E       TypeError: ufunc 'multiply' output (typecode 'O') could not be coerced to provided output parameter (typecode 'd') according to the casting rule ''same_kind''

/home/msyriac/repos/so_pysm_models/so_pysm_models/alms.py:84: TypeError
--------------------------------------------------------------- Captured stdout call ----------------------------------------------------------------
Sigma is 0.000000 arcmin (0.000000 rad) 
-> fwhm is 0.000000 arcmin
======================================================== 1 failed, 3 passed in 0.79 seconds =========================================================

```